### PR TITLE
Knockback Edit Request

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -555,14 +555,14 @@ abstract class Living extends Entity implements Damageable{
 			$e = $source->getChild();
 			if($e !== null){
 				$motion = $e->getMotion();
-				$this->knockBack($e, $source->getBaseDamage(), $motion->x, $motion->z, $source->getKnockBack());
+				$this->knockBack($e, $source->getBaseDamage(), $motion->x, $motion->z, $source->getHorizontalKnockback(), $source->getVerticalKnockback());
 			
 		}elseif($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
 			if($e !== null){
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
-				$this->knockBack($e, $source->getBaseDamage(), $deltaX, $deltaZ, $source->getKnockBack());
+				$this->knockBack($e, $source->getBaseDamage(), $deltaX, $deltaZ, $source->getHorizontalKnockback(), $source->getVerticalKnockback());
 			}
 		}
 

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -539,8 +539,13 @@ abstract class Living extends Entity implements Damageable{
 		){
 			//TODO: knockback should not just apply for entity damage sources
 			//this doesn't matter for TNT right now because the PrimedTNT entity is considered the source, not the block.
-			$base = $source->getKnockBack();
-			$source->setKnockBack($base - min($base, $base * $this->getHighestArmorEnchantmentLevel(Enchantment::BLAST_PROTECTION) * 0.15));
+			
+			// Does calculations for vertical & horizontal knockback.
+			$baseHorizontal = $source->getHorizontalKnockback();
+			$baseVertical = $source->getVerticalKnockback();
+			$newHorizontal = $baseHorizontal - min($baseHorizontal, $baseHorizontal * $this->getHighestArmorEnchantmentLevel(Enchantment::BLAST_PROTECTION) * 0.15);
+			$newVertical = $baseVertical - min($baseVertical, $baseVertical * $this->getHighestArmorEnchantmentLevel(Enchantment::BLAST_PROTECTION) * 0.15);
+			$source->setKnockBack($newHorizontal, $newVertical);
 		}
 
 		parent::attack($source);

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -533,10 +533,13 @@ abstract class Living extends Entity implements Damageable{
 
 		$this->applyDamageModifiers($source);
 
-		if($source instanceof EntityDamageByEntityEvent and (
-			$source->getCause() === EntityDamageEvent::CAUSE_BLOCK_EXPLOSION or
+		if
+        (
+            $source instanceof EntityDamageByEntityEvent and
+            ($source->getCause() === EntityDamageEvent::CAUSE_BLOCK_EXPLOSION or
 			$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_EXPLOSION)
-		){
+		)
+		{
 			//TODO: knockback should not just apply for entity damage sources
 			//this doesn't matter for TNT right now because the PrimedTNT entity is considered the source, not the block.
 			
@@ -558,13 +561,16 @@ abstract class Living extends Entity implements Damageable{
 
 		if($source instanceof EntityDamageByChildEntityEvent){
 			$e = $source->getChild();
-			if($e !== null){
-				$motion = $e->getMotion();
-				$this->knockBack($e, $source->getBaseDamage(), $motion->x, $motion->z, $source->getHorizontalKnockback(), $source->getVerticalKnockback());
-			
+			if($e !== null) {
+                $motion = $e->getMotion();
+                $this->knockBack($e, $source->getBaseDamage(), $motion->x, $motion->z, $source->getHorizontalKnockback(), $source->getVerticalKnockback());
+            }
+
 		}elseif($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
 			if($e !== null){
+			    // Testing purposes
+                $source->setVerticalKnockback(4);
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
 				$this->knockBack($e, $source->getBaseDamage(), $deltaX, $deltaZ, $source->getHorizontalKnockback(), $source->getVerticalKnockback());
@@ -581,7 +587,8 @@ abstract class Living extends Entity implements Damageable{
 		$this->broadcastEntityEvent(ActorEventPacket::HURT_ANIMATION);
 	}
 
-	public function knockBack(Entity $attacker, float $damage, float $x, float $z, float $base = 0.4, ?float $baseY = null) : void{
+	public function knockBack(Entity $attacker, float $damage, float $x, float $z, float $base = 0.4, ?float $baseY = null) : void
+        {
 		
 		$f = sqrt($x * $x + $z * $z);
 		

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -569,8 +569,6 @@ abstract class Living extends Entity implements Damageable{
 		}elseif($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
 			if($e !== null){
-			    // Testing purposes
-                $source->setVerticalKnockback(4);
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
 				$this->knockBack($e, $source->getBaseDamage(), $deltaX, $deltaZ, $source->getHorizontalKnockback(), $source->getVerticalKnockback());

--- a/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
@@ -31,17 +31,21 @@ use pocketmine\entity\Living;
  * Called when an entity takes damage from another entity.
  */
 class EntityDamageByEntityEvent extends EntityDamageEvent{
+	
 	/** @var int */
 	private $damagerEntityId;
 	/** @var float */
-	private $knockBack;
+	private $horizontalKnockback;
+	/** @var float|null */
+	private $verticalKnockback;
 
 	/**
 	 * @param float[] $modifiers
 	 */
-	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], float $knockBack = 0.4){
+	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], float $horizontalKnockback = 0.4, ?float $verticalKnockback = null){
 		$this->damagerEntityId = $damager->getId();
-		$this->knockBack = $knockBack;
+		$this->horizontalKnockback = $horizontalKnockback;
+		$this->verticalKnockback = $verticalKnockback;
 		parent::__construct($entity, $cause, $damage, $modifiers);
 		$this->addAttackerModifiers($damager);
 	}
@@ -65,11 +69,43 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 		return $this->getEntity()->getLevelNonNull()->getServer()->findEntity($this->damagerEntityId);
 	}
 
+	/**
+	 * Returns the horizontal Knockback of the Event.
+	 * Use the function getHorizontalKnockback().
+	 
+	 * @return float - The horizontal knockback.
+	 * @deprecated
+	 */
 	public function getKnockBack() : float{
-		return $this->knockBack;
+		return $this->horizontalKnockback;
+	}
+	
+	/**
+	 * Returns the horizontal knockback value.
+	 * @return float - The horizontal knockback.
+	 */
+	public function getHorizontalKnockback(): float {
+		return $this->horizontalKnockback;
+	}
+	
+	/**
+	 * Returns the vertical knockback value. If internal knockback value
+	 * is null, it returns the horizontal knockback.
+	 * @return float - The vertical knockback.
+	 */
+	public function getVerticalKnockback(): float {
+		return $this->verticalKnockback ?? $this->horizontalKnockback;
 	}
 
-	public function setKnockBack(float $knockBack) : void{
-		$this->knockBack = $knockBack;
+	/**
+	 * Sets the Knockback of the event.
+	 * @param float $horizontalKnockback - The horizontal knockback of the player.
+	 * @param float|null $verticalKnockback - The vertical knockback of the player.
+	 */
+	public function setKnockBack(float $horizontalKnockback, ?float $verticalKnockback = null) : void{
+		$this->horizontalKnockback = $horizontalKnockback;
+		if($verticalKnockback !== null) {
+			$this->verticalKnockback = $verticalKnockback;
+		}
 	}
 }

--- a/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
@@ -98,16 +98,18 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	}
 
 	/**
-	 * Sets the horizontal and possibly the vertical knockback if parameter is filled.
+	 * Sets the horizontal and vertical knockback.
+     * - If vertical knockback isn't filled, the vertical knockback
+     *   is set to the horizontal knockback, which is the same functionality
+     *   as before.
 	 *
 	 * @param float $horizontalKnockback - The horizontal knockback of the event.
 	 * @param float|null $verticalKnockback - The vertical knockback of the event.
 	 */
 	public function setKnockBack(float $horizontalKnockback, ?float $verticalKnockback = null) : void{
-		$this->horizontalKnockback = $horizontalKnockback;
-		if($verticalKnockback !== null) {
-			$this->verticalKnockback = $verticalKnockback;
-		}
+		// Sets vertical and horizontal kb.
+	    $this->horizontalKnockback = $horizontalKnockback;
+		$this->verticalKnockback = ($verticalKnockback ?? $horizontalKnockback);
 	}
 	
 	/**
@@ -115,15 +117,20 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	 * @param float - The horizontal knockback of the event.
 	 */
 	public function setHorizontalKnockback(float $horizontalKnockback): void {
+	    // Sets the vertical knockback to the previous horizontal knockback.
+	    if($this->verticalKnockback === null)
+        {
+            $this->verticalKnockback = $this->horizontalKnockback;
+        }
 		$this->horizontalKnockback = $horizontalKnockback;
 	}
 	
 	/** 
 	 * Sets the vertical knockback of the event directly without needing
 	 * to also set the horizontal knockback.
-	 * @param $knockback - The vertical knockback.
+	 * @param $verticalKnockback - The vertical knockback.
 	 */
-	public function setVerticalKnockback(float $knockback): void {
-		$this->verticalKnockback = $knockback;
+	public function setVerticalKnockback(float $verticalKnockback): void {
+		$this->verticalKnockback = $verticalKnockback;
 	}
 }

--- a/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
@@ -98,14 +98,32 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	}
 
 	/**
-	 * Sets the Knockback of the event.
-	 * @param float $horizontalKnockback - The horizontal knockback of the player.
-	 * @param float|null $verticalKnockback - The vertical knockback of the player.
+	 * Sets the horizontal and possibly the vertical knockback if parameter is filled.
+	 *
+	 * @param float $horizontalKnockback - The horizontal knockback of the event.
+	 * @param float|null $verticalKnockback - The vertical knockback of the event.
 	 */
 	public function setKnockBack(float $horizontalKnockback, ?float $verticalKnockback = null) : void{
 		$this->horizontalKnockback = $horizontalKnockback;
 		if($verticalKnockback !== null) {
 			$this->verticalKnockback = $verticalKnockback;
 		}
+	}
+	
+	/**
+	 * Sets the horizontal knockback of the event directly. Added for clarification purposes.
+	 * @param float - The horizontal knockback of the event.
+	 */
+	public function setHorizontalKnockback(float $horizontalKnockback): void {
+		$this->horizontalKnockback = $horizontalKnockback;
+	}
+	
+	/** 
+	 * Sets the vertical knockback of the event directly without needing
+	 * to also set the horizontal knockback.
+	 * @param $knockback - The vertical knockback.
+	 */
+	public function setVerticalKnockback(float $knockback): void {
+		$this->verticalKnockback = $knockback;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request adds more flexibility to developers trying to add completely customizable knockback. Instead of a base knockback value that controls both the horizontal knockback (how far the entity goes after each hit) and the vertical knockback (how high the entity goes after each hit), this pull request separates the base horizontal and base vertical knockback values so allow for more customization without needing to create a Player class as shown in my plugin: https://github.com/jkorn2324/PvPCore. 

### Relevant issues
<!-- List relevant issues here -->
<!--
-->
No issues so far.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

**Added Methods:**
EntityDamageByEntityEvent->getHorizontalKnockback();
EntityDamageByEntityEvent->getVerticalKnockback();
EntityDamageByEntityEvent->setHorizontalKnockback();
EntityDamageByEntityEvent->setVerticalKnockback();

**Changed Methods:**
EntityDamageByEntityEvent->setKnockBack();
EntityDamageByEntityEvent->getKnockBack();
Living->knockBack();

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No Behavioural changes, just API changes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This is backwards-compatible with the current API.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Determine whether the function names in EntityDamageByEntityEvent are clear enough and whether or not I even need the setVerticalKnockback/setHorizontalKnockback functions if the function names are confusing.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested by changing the Horizontal Knockback, Vertical Knockback in a plugin using this updated API and by going on a test server and having two players hit each other.